### PR TITLE
fix #2: Next page xpath fixed

### DIFF
--- a/src/sofifa_parser/sofifa_parser/spiders/players_url.py
+++ b/src/sofifa_parser/sofifa_parser/spiders/players_url.py
@@ -23,7 +23,7 @@ class SofifaSpider(scrapy.Spider):
 					'player_url': player_link[0]
 				}
 
-		next_page = response.xpath('.//a[@class="pjax btn"]/@href').extract()
+		next_page = response.xpath('.//a[@class="bp3-button pjax"]/@href').extract()
 		if next_page:
 			if len(next_page) == 1:
 				next_href = next_page[0]


### PR DESCRIPTION
Updated xpath from
```
.//a[@class="pjax btn"]/@href
```
to
```
'.//a[@class="bp3-button pjax"]/@href'
```

Referenced from [https://sofifa.com/players?offset=0](https://sofifa.com/players?offset=0)